### PR TITLE
chore: Add missing BREAKING_CHANGES.md, CODE_OF_CONDUCT.md, CONTRIBUT…

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,0 +1,5 @@
+# Breaking Changes
+
+## x.x.x
+
+Breaking change description

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,78 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at info@nventive.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# How to Contribute
+
+We'd love to accept your patches, contributions and suggestions to this project.
+Here are a few small guidelines you need to follow.
+
+## Code of conduct
+
+To better foster an open, innovative and inclusive community please refer to our
+[Code of Conduct](CODE_OF_CONDUCT.md) when contributing.
+
+### Report a bug
+
+If you think you've found a bug, please log a new issue in the [GitHub issue
+tracker. When filing issues, please use our [issue
+template](.github/ISSUE_TEMPLATE.md). The best way to get your bug fixed is to
+be as detailed as you can be about the problem. Providing a minimal project with
+steps to reproduce the problem is ideal. Here are questions you can answer
+before you file a bug to make sure you're not missing any important information.
+
+1. Did you read the documentation?
+2. Did you include the snippet of broken code in the issue?
+3. What are the *EXACT* steps to reproduce this problem?
+4. What specific version or build are you using?
+5. What operating system are you using?
+
+GitHub supports
+[markdown](https://help.github.com/articles/github-flavored-markdown/), so when
+filing bugs make sure you check the formatting before clicking submit.
+
+### Make a suggestion
+
+If you have an idea for a new feature or enhancement let us know by filing an
+issue. To help us understand and prioritize your idea please provide as much
+detail about your scenario and why the feature or enhancement would be useful.
+
+## Contributing code and content
+
+This is an open source project and we welcome code and content contributions
+from the community.
+
+**Identifying the scale**
+
+If you would like to contribute to this project, first identify the scale of
+what you would like to contribute. If it is small (grammar/spelling or a bug
+fix) feel free to start working on a fix.
+
+If you are submitting a feature or substantial code contribution, please discuss
+it with the team. You might also read these two blogs posts on contributing
+code: [Open Source Contribution
+Etiquette](http://tirania.org/blog/archive/2010/Dec-31.html) by Miguel de Icaza
+and [Don't "Push" Your Pull
+Requests](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/) by
+Ilya Grigorik. Note that all code submissions will be rigorously reviewed and
+tested by the project team, and only those that meet an extremely high bar for
+both quality and design/roadmap appropriateness will be merged into the source.
+
+**Obtaining the source code**
+
+If you are an outside contributor, please fork the repository to your account.
+See the GitHub documentation for [forking a
+repo](https://help.github.com/articles/fork-a-repo/) if you have any questions
+about this.
+
+**Submitting a pull request**
+
+If you don't know what a pull request is read this article:
+https://help.github.com/articles/using-pull-requests. Make sure the repository
+can build and all tests pass, as well as follow the current coding guidelines.
+When submitting a pull request, please use our [pull request
+template](.github/PULL_REQUEST_TEMPLATE.md).
+
+Pull requests should all be done to the **master** branch.
+
+---
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult [GitHub
+Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Community Guidelines
+
+This project follows [Google's Open Source Community
+Guidelines](https://opensource.google.com/conduct/).


### PR DESCRIPTION
GitHub Issue: #


## Proposed Changes

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [x] Documentation content changes
 - [x] Other, please describe:

This PR adds the missing Add missing CODE_OF_CONDUCT.md, CONTRIBUTING.md files.

## What is the current behavior?

no changes


## What is the new behavior?

no changes

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Commits have been squashed (if applicable).
- [x] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a

